### PR TITLE
update storage api to allow for pantry and ad hoc items

### DIFF
--- a/src/app/components/add-pantry-item/add-pantry-item.component.ts
+++ b/src/app/components/add-pantry-item/add-pantry-item.component.ts
@@ -32,8 +32,6 @@ export class AddPantryItemComponent {
 		}
 		await this.storage.set(slug, {
 			name: this.newItemName,
-			created: new Date(),
-			modified: new Date(),
 		})
 		this.adding = false
 		this.newItemName = ''

--- a/src/app/components/pantry-list/pantry-list.component.ts
+++ b/src/app/components/pantry-list/pantry-list.component.ts
@@ -19,7 +19,7 @@ export class PantryListComponent implements OnInit {
 	constructor(public storage: StorageService, public modalController: ModalController) {}
 
 	async loadPantryList() {
-		this.pantryItemsRaw$ = await this.storage.get_all()
+		this.pantryItemsRaw$ = await this.storage.get_all(true, false)
 
 		combineLatest([this.pantryItemsRaw$, this.searchTerm$]).subscribe(([pantryEntries, searchTerm]) => {
 			if (searchTerm === null) {

--- a/src/app/components/shopping-list/shopping-list.component.ts
+++ b/src/app/components/shopping-list/shopping-list.component.ts
@@ -25,16 +25,14 @@ export class ShoppingListComponent implements OnInit {
 
 	async loadPantryList(): Promise<void> {
 		this.pantryList$ = await this.storage.get_all(true, false)
-		const adHoc = await this.storage.get_all(false, true)
-		adHoc.subscribe(adHocEntryList => {
-			this.inCart = adHocEntryList
-		})
+		const adHoc$ = await this.storage.get_all(false, true)
+		const adHocList = await adHoc$.toPromise()
+		this.inCart = adHocList
 
-		this.pantryList$.subscribe(pantryList => {
-			this.runningLow = pantryList.filter(([, pantryItem]) => pantryItem.runningLow && !pantryItem.inCart)
-			this.outOf = pantryList.filter(([, pantryItem]) => pantryItem.out && !pantryItem.inCart)
-			this.inCart = this.inCart.concat(pantryList.filter(([, pantryItem]) => pantryItem.inCart))
-		})
+		const pantryList = await this.pantryList$.toPromise()
+		this.runningLow = pantryList.filter(([, pantryItem]) => pantryItem.runningLow && !pantryItem.inCart)
+		this.outOf = pantryList.filter(([, pantryItem]) => pantryItem.out && !pantryItem.inCart)
+		this.inCart = this.inCart.concat(pantryList.filter(([, pantryItem]) => pantryItem.inCart))
 	}
 
 	async ngOnInit(): Promise<void> {

--- a/src/types/pantry-types.ts
+++ b/src/types/pantry-types.ts
@@ -1,9 +1,17 @@
 export interface PantryItem {
 	name: string
-	created?: Date
 	modified?: Date
 	runningLow?: boolean
 	out?: boolean
+	inCart?: boolean
+}
+
+export interface AdHocShoppingItem {
+	name: string
+	modified?: Date
 }
 
 export type PantryEntry = [string, PantryItem]
+export type AdHocShoppingEntry = [string, AdHocShoppingItem]
+
+// the strings in these types are the slug name / keys


### PR DESCRIPTION
Adds new top level type `AdHocShoppingItem`.  Updates get_all to take arguments, so you can specify if you want all pantry items, all shopping items, or both

Updates the pantry and shopping components to get the appropriate lists

Updates the shopping list page to load on ionViewDidEnter (so tabbing to pantry, marking something low, and tabbing back to shopping list updates correctly)

Tracks `inCart` attribute, so marking something on the shopping list in cart persists.

Adds argument to slugName function to produce a pantry or adHoc slug


Does _not_ implement any new list manipulation functionality (ie no way to add ad hoc entries, no way to do anything once something in cart - thats for a differnet PR)